### PR TITLE
v0.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   ],
   "hoist": true,
   "npmClient": "yarn",
-  "version": "0.2.5"
+  "version": "0.3.0"
 }

--- a/packages/react-redux-modules/package.json
+++ b/packages/react-redux-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wtg/react-redux-modules",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "`react-redux` for `@wtg/redux-modules`.",
   "license": "MIT",
   "author": "Matthew Fernando Garcia",

--- a/packages/redux-modules-test-utils/package.json
+++ b/packages/redux-modules-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wtg/redux-modules-test-utils",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Test utilities for `@wtg/redux-modules`.",
   "main": "lib/index.js",
   "repository": "https://github.com/wtgtybhertgeghgtwtg/redux-modules/tree/master/packages/redux-modules-test-utils",

--- a/packages/redux-modules/package.json
+++ b/packages/redux-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wtg/redux-modules",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "A simplistic alternate approach to https://github.com/procore/redux-modules.",
   "license": "MIT",
   "repository": "https://github.com/wtgtybhertgeghgtwtg/redux-modules/tree/master/packages/redux-modules",


### PR DESCRIPTION
Removes `@wtg/redux-modules-saga`.  It was a cool idea, but it didn't offer enough to warrant the effort.
It was fun to worth with, though.