### PR TITLE
[@wtg/redux-modules] Remove `T` type argument from `ReduxModule`.

### DIFF
--- a/packages/react-redux-modules/__tests__/connect.test.js
+++ b/packages/react-redux-modules/__tests__/connect.test.js
@@ -10,7 +10,7 @@ jest.mock('../src/connectComponent', () => {
   return jest.fn(
     <S, OP, SP>(
       selector: MapStateToProps<S, OP, SP>,
-      modules: Array<ReduxModule<Object, any, any>>,
+      modules: Array<ReduxModule<Object, any>>,
       options: ConnectOptions,
     ) => {
       expect(typeof selector).toEqual('function');

--- a/packages/react-redux-modules/src/Provider.js
+++ b/packages/react-redux-modules/src/Provider.js
@@ -11,7 +11,7 @@ import type {ReducerMap} from './types';
 export type CreateRegisterModules<S, A> = (
   store: Store<S, A>,
   reducers: ?ReducerMap,
-) => (modules: Array<ReduxModule<*, *, *>>) => void;
+) => (modules: Array<ReduxModule<*, *>>) => void;
 
 export type ProviderProps<S, A> = {
   children?: any,
@@ -32,7 +32,7 @@ export default class Provider<S: Object, A> extends Component<
   ProviderProps<S, A>,
 > {
   props: ProviderProps<S, A>;
-  registerModules: (modules: Array<ReduxModule<*, *, *>>) => void;
+  registerModules: (modules: Array<ReduxModule<*, *>>) => void;
   store: Store<S, *>;
 
   static childContextTypes = {

--- a/packages/react-redux-modules/src/connect.js
+++ b/packages/react-redux-modules/src/connect.js
@@ -8,9 +8,7 @@ import connectComponent from './connectComponent';
 import createImplicitSelector from './createImplicitSelector';
 import type {ConnectOptions} from './types';
 
-type Modules =
-  | Array<ReduxModule<Object, Object, Object>>
-  | ReduxModule<Object, Object, Object>;
+type Modules = ReduxModule<Object, {}> | Array<ReduxModule<Object, {}>>;
 
 /**
  * Creates a higher-order component that connects a React component to one or more ReduxModules.  The actionCreators and assosciated state of the modules will be passed as props to the component.
@@ -40,7 +38,8 @@ export default function connect(
   } else {
     invariant(!Array.isArray(modules), '`options` must be a plain object.');
     options = {connectWrapper: identity, ...modules};
-    modules = (castArray(selector): Array<ReduxModule<Object, Object, Object>>);
+    modules = castArray(selector);
+    // modules = (castArray(selector): Array<ReduxModule<Object, Object>>);
     selector = createImplicitSelector(modules);
   }
   return connectComponent(selector, modules, options);

--- a/packages/react-redux-modules/src/connectComponent.js
+++ b/packages/react-redux-modules/src/connectComponent.js
@@ -22,7 +22,7 @@ export default function connectComponent<
   DP: Object,
 >(
   selector: MapStateToProps<S, OP, SP>,
-  modules: Array<ReduxModule<Object, Object, Object>>,
+  modules: Array<ReduxModule<Object, {}>>,
   options: ConnectOptions,
 ) {
   const {connectWrapper, ...reactReduxOptions} = options;

--- a/packages/react-redux-modules/src/createImplicitSelector.js
+++ b/packages/react-redux-modules/src/createImplicitSelector.js
@@ -17,7 +17,7 @@ import type {MapStateToProps} from 'react-redux';
  * @return {Selector} The created selector function.
  */
 export default function createImplicitSelector<S: Object>(
-  modules: Array<ReduxModule<$Shape<S>, Object, Object>>,
+  modules: Array<ReduxModule<$Shape<S>, {}>>,
 ): MapStateToProps<{[name: string]: $Shape<S>}, Object, S> {
   const names = modules.map(reduxModule => reduxModule.name);
   return state => {

--- a/packages/react-redux-modules/src/defaultCreateRegisterModules.js
+++ b/packages/react-redux-modules/src/defaultCreateRegisterModules.js
@@ -17,7 +17,7 @@ export default function defaultCreateRegisterModules<S: Object>(
   reducers: ?ReducerMap,
 ): RegisterModules {
   const registry: ReducerMap = {...reducers};
-  return function registerModules(modules: Array<ReduxModule<*, *, *>>) {
+  return function registerModules(modules: Array<ReduxModule<*, *>>) {
     const unregisteredModules = modules.filter(
       ({name}) => !has(registry, name),
     );

--- a/packages/react-redux-modules/src/defaultMapModulesToProps.js
+++ b/packages/react-redux-modules/src/defaultMapModulesToProps.js
@@ -9,11 +9,11 @@ import type {MapDispatchToProps} from 'react-redux';
  * @param {Array<ReduxModule>} modules Modules whose actionCreators will be passed as props to the component.
  * @return {Object} The combined actionCreators from `modules`.
  */
-export default function defaultMapModulesToProps<DP: Object>(
-  modules: Array<ReduxModule<Object, $Shape<DP>, Object>>,
+export default function defaultMapModulesToProps<DP: {}>(
+  modules: Array<ReduxModule<Object, $Shape<DP>>>,
 ): MapDispatchToProps<*, *, DP> {
   const actionCreators = modules.map(
-    <A: $Shape<DP>>(reduxModule: ReduxModule<*, A, *>) =>
+    <A: $Shape<DP>>(reduxModule: ReduxModule<*, A>) =>
       reduxModule.actionCreators,
   );
   return Object.assign({}, ...actionCreators);

--- a/packages/react-redux-modules/src/types.js
+++ b/packages/react-redux-modules/src/types.js
@@ -21,4 +21,4 @@ export type ReducerMap = {
   [name: string]: Reducer<*, *>,
 };
 
-export type RegisterModules = (modules: Array<ReduxModule<*, *, *>>) => void;
+export type RegisterModules = (modules: Array<ReduxModule<*, *>>) => void;

--- a/packages/redux-modules-test-utils/src/bindModule.js
+++ b/packages/redux-modules-test-utils/src/bindModule.js
@@ -37,7 +37,7 @@ type ExtractBoundModule<S> = <P, M>(
  * @return {BoundModule} The bound module.
  */
 export default function bindModule<S: Object, A: ActionCreators>(
-  reduxModule: ReduxModule<S, A, *>,
+  reduxModule: ReduxModule<S, A>,
 ): BoundModule<S, A> {
   const {actionCreators, reducer} = reduxModule;
   const bindActionCreator = <P, M>(actionCreator: ActionCreator<P, M>) => (

--- a/packages/redux-modules-test-utils/src/bindModuleWithState.js
+++ b/packages/redux-modules-test-utils/src/bindModuleWithState.js
@@ -41,7 +41,7 @@ type ExtractBoundModuleWithState<S> = <P, M>(
  * @return {BoundModule} The bound module.
  */
 export default function bindModuleWithState<S: Object, A: ActionCreators>(
-  reduxModule: ReduxModule<S, A, *>,
+  reduxModule: ReduxModule<S, A>,
   state: S,
 ): BoundModuleWithState<S, A> {
   const {actionCreators, reducer} = reduxModule;

--- a/packages/redux-modules/__tests__/createModule.test.js
+++ b/packages/redux-modules/__tests__/createModule.test.js
@@ -8,7 +8,6 @@ import type {
   ActionCreator,
   CreateModuleOptions,
   ExtractActionCreatorType,
-  ExtractTypeType,
   ImplicitTransformations,
   ReduxModule,
 } from '../src/types';
@@ -16,11 +15,7 @@ import type {
 // eslint-disable-next-line require-jsdoc
 function harness<S: Object, C: ImplicitTransformations<S>>(
   options: CreateModuleOptions<S, C>,
-): ReduxModule<
-  S,
-  $ObjMap<C, ExtractActionCreatorType>,
-  $ObjMap<C, ExtractTypeType>,
-> {
+): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {
   const {initialState, name, transformations} = options;
   const transformationKeys = transformations
     ? Object.keys(transformations)

--- a/packages/redux-modules/__tests__/defaultModuleCreator.test.js
+++ b/packages/redux-modules/__tests__/defaultModuleCreator.test.js
@@ -7,7 +7,6 @@ import type {
   Action,
   ActionCreator,
   ExtractActionCreatorType,
-  ExtractTypeType,
   NormalizedCreateModuleOptions,
   ReduxModule,
   Transformations,
@@ -16,11 +15,7 @@ import type {
 // eslint-disable-next-line require-jsdoc
 function harness<S: Object, C: Transformations<S>>(
   options: NormalizedCreateModuleOptions<S, C>,
-): ReduxModule<
-  S,
-  $ObjMap<C, ExtractActionCreatorType>,
-  $ObjMap<C, ExtractTypeType>,
-> {
+): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {
   const {initialState, name, transformations} = options;
   const transformationKeys = Object.keys(transformations);
   const testModule = defaultModuleCreator(options);

--- a/packages/redux-modules/src/createModule.js
+++ b/packages/redux-modules/src/createModule.js
@@ -5,7 +5,6 @@ import type {
   CreateModuleOptions,
   ExtractActionCreatorType,
   ExtractTransformationType,
-  ExtractTypeType,
   ImplicitTransformations,
   ModuleCreator,
   ReduxModule,
@@ -37,11 +36,7 @@ export default function createModule<S: Object, C: ImplicitTransformations<S>>(
     S,
     $ObjMap<C, ExtractTransformationType>,
   > = defaultModuleCreator,
-): ReduxModule<
-  S,
-  $ObjMap<C, ExtractActionCreatorType>,
-  $ObjMap<C, ExtractTypeType>,
-> {
+): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {
   const normalOptions = normalizeOptions(options);
   return moduleCreator(normalOptions);
 }

--- a/packages/redux-modules/src/defaultModuleCreator.js
+++ b/packages/redux-modules/src/defaultModuleCreator.js
@@ -6,7 +6,6 @@ import createReducer from './createReducer';
 import formatType from './formatType';
 import type {
   ExtractActionCreatorType,
-  ExtractTypeType,
   NormalizedCreateModuleOptions,
   ReduxModule,
   Transformation,
@@ -21,11 +20,7 @@ import type {
  */
 export default function defaultModuleCreator<S: Object, C: Transformations<S>>(
   options: NormalizedCreateModuleOptions<S, C>,
-): ReduxModule<
-  S,
-  $ObjMap<C, ExtractActionCreatorType>,
-  $ObjMap<C, ExtractTypeType>,
-> {
+): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {
   const {initialState, name, transformations} = options;
   const actionCreators = Object.create(null);
   const types = Object.create(null);

--- a/packages/redux-modules/src/types.js
+++ b/packages/redux-modules/src/types.js
@@ -39,11 +39,7 @@ export type ImplicitTransformations<S: Object> = StringMap<
 
 export type ModuleCreator<S: Object, C: Transformations<S>> = (
   options: NormalizedCreateModuleOptions<S, C>,
-) => ReduxModule<
-  S,
-  $ObjMap<C, ExtractActionCreatorType>,
-  $ObjMap<C, ExtractTypeType>,
->;
+) => ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>>;
 
 export type NormalizedCreateModuleOptions<S: Object, C: Transformations<S>> = {
   initialState: S,
@@ -53,11 +49,11 @@ export type NormalizedCreateModuleOptions<S: Object, C: Transformations<S>> = {
 
 export type ReducerMap<S> = Map<string, Reducer<S, *>>;
 
-export type ReduxModule<S: Object, A: ActionCreators, T: Types> = {
+export type ReduxModule<S: Object, A: ActionCreators> = {
   actionCreators: A,
   name: string,
   reducer: Reducer<S, *>,
-  types: T,
+  types: $ObjMap<A, ExtractTypeType>,
 };
 
 export type StringMap<T> = {


### PR DESCRIPTION
It greatly simplifies working with Flow in some areas.  Now Prettier won't split everything into multiple lines.