### PR TITLE
[@wtg/redux-modules-test-utils] Add `wrapActionCreators`.

### DIFF
--- a/packages/redux-modules-test-utils/__tests__/wrapActionCreators.test.js
+++ b/packages/redux-modules-test-utils/__tests__/wrapActionCreators.test.js
@@ -1,0 +1,30 @@
+// @flow
+import {forEach, identity} from 'lodash';
+
+import wrapActionCreators from '../src/wrapActionCreators';
+import createModule, {type ActionCreator} from '../../redux-modules/src';
+
+describe('`wrapActionCreators`', () => {
+  const reduxModule = createModule({
+    initialState: {},
+    name: 'test',
+    transformations: {
+      doOtherThing: identity,
+      doThing: identity,
+    },
+  });
+  const wrapper: any => any = jest.fn(identity);
+  wrapActionCreators(reduxModule, wrapper);
+  it('passes each action creator to `wrapper`.', () => {
+    forEach(
+      reduxModule.actionCreators,
+      (actionCreator: ActionCreator<*, *>) => {
+        expect(wrapper).toHaveBeenCalledWith(
+          actionCreator,
+          expect.anything(),
+          expect.anything(),
+        );
+      },
+    );
+  });
+});

--- a/packages/redux-modules-test-utils/src/index.js
+++ b/packages/redux-modules-test-utils/src/index.js
@@ -1,5 +1,9 @@
 // @flow
-import bindModule from './bindModule';
-import bindModuleWithState from './bindModuleWithState';
+export {default as bindModule} from './bindModule';
+export {default as bindModuleWithState} from './bindModuleWithState';
+export {default as wrapActionCreators} from './wrapActionCreators';
 
-export {bindModule, bindModuleWithState};
+// Since `export {default as x, type Y} from './x'` apparently isn't kosher.
+export type {BoundModule} from './bindModule';
+export type {BoundModuleWithState} from './bindModuleWithState';
+export type {ActionCreatorWrapper} from './wrapActionCreators';

--- a/packages/redux-modules-test-utils/src/wrapActionCreators.js
+++ b/packages/redux-modules-test-utils/src/wrapActionCreators.js
@@ -1,0 +1,48 @@
+// @flow
+import type {
+  ActionCreator,
+  ActionCreators,
+  ReduxModule,
+} from '@wtg/redux-modules';
+import {mapValues} from 'lodash';
+
+export type ActionCreatorWrapper = <P, M>(
+  actionCreator: ActionCreator<P, M>,
+  name: string,
+) => ActionCreator<P, M>;
+
+/**
+ * Wraps the actionCreators of a module with a function and returns a new module.
+ * @example
+ * // Create a module.
+ * const counterModule = createModule({
+ *   initialState: {
+ *     count: 0,
+ *   },
+ *   name: 'counter',
+ *   transformations: {
+ *     increment: state => ({...state, count: state.count + 1}),
+ *     incrementBy: (state, action) => ({...state, count: state.count + action.payload}),
+ *   },
+ * });
+ * // Wrap the actionCreators.  Here using `jest.fn`.
+ * const wrapped = wrapActionCreators(counterModule, jest.fn);
+ * wrapped.actionCreators.incrementBy(4);
+ * // Passes, since `incrementBy` has been wrapped with `jest.fn`.
+ * expect(wrapped.actionCreators.incrementBy).toHaveBeenCalledWith(4);
+ * @example
+ * @param {ReduxModule} reduxModule The module whose actionCreators will be bound.
+ * @param {ActionCreatorWrapper} wrapper The wrapper function.
+ * @return {ReduxModule} The module with its actionCreators bound.
+ */
+export default function wrapActionCreators<S: Object, A: ActionCreators>(
+  reduxModule: ReduxModule<S, A>,
+  wrapper: ActionCreatorWrapper,
+): ReduxModule<S, A> {
+  // $FlowFixMe `mapValues` doesn't preserve type information.
+  const boundActionCreators: A = mapValues(reduxModule.actionCreators, wrapper);
+  return {
+    ...reduxModule,
+    actionCreators: boundActionCreators,
+  };
+}


### PR DESCRIPTION
It's pretty much just for `jest.fn`, but Jest is pretty squirrelly about calling things in helper packages.