### PR TITLE
[all] Add `.eslintrc.js` to each `__tests__`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
-    "babel-jest": "^21.0.2",
+    "babel-jest": "^21.2.0",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-use-lodash-es": "^0.1.0",
     "babel-preset-env": "^1.6.0",
@@ -11,12 +11,12 @@
     "babel-preset-stage-0": "^6.22.0",
     "cross-env": "^5.0.5",
     "eslint": "^4.7.2",
-    "eslint-config-fb-strict": "^21.0.2",
+    "eslint-config-fb-strict": "^21.2.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.36.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jasmine": "^2.8.4",
-    "eslint-plugin-jest": "^21.1.0",
+    "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-react": "^7.4.0",
@@ -24,13 +24,13 @@
     "flow-bin": "^0.55.0",
     "flow-copy-source": "^1.2.1",
     "flux-standard-action": "^1.1.0",
-    "jest": "^21.1.0",
+    "jest": "^21.2.1",
     "lerna": "^2.2.0",
     "lodash": "^4.2.1",
-    "prettier": "^1.7.0",
+    "prettier": "^1.7.2",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
@@ -42,37 +42,27 @@
   },
   "private": "true",
   "scripts": {
-    "build":
-      "yarn run build:redux-modules && yarn run build:react-redux-modules && yarn run build:redux-modules-test-utils",
-    "build:react-redux-modules":
-      "yarn run build:react-redux-modules:commonjs && yarn run build:react-redux-modules:es",
-    "build:react-redux-modules:commonjs":
-      "cross-env BABEL_ENV=commonjs babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/lib",
-    "build:react-redux-modules:es":
-      "cross-env BABEL_ENV=es babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/es",
-    "build:redux-modules":
-      "yarn run build:redux-modules:commonjs && yarn run build:redux-modules:es",
-    "build:redux-modules-test-utils":
-      "yarn run build:redux-modules-test-utils:commonjs && yarn run build:redux-modules-test-utils:es",
-    "build:redux-modules-test-utils:commonjs":
-      "cross-env BABEL_ENV=commonjs babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/lib",
-    "build:redux-modules-test-utils:es":
-      "cross-env BABEL_ENV=es babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/es",
-    "build:redux-modules:commonjs":
-      "cross-env BABEL_ENV=commonjs babel packages/redux-modules/src --out-dir packages/redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/lib",
-    "build:redux-modules:es":
-      "cross-env BABEL_ENV=es babel packages/redux-modules/src --out-dir packages/redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/es",
+    "build": "yarn run build:redux-modules && yarn run build:react-redux-modules && yarn run build:redux-modules-test-utils",
+    "build:react-redux-modules": "yarn run build:react-redux-modules:commonjs && yarn run build:react-redux-modules:es",
+    "build:react-redux-modules:commonjs": "cross-env BABEL_ENV=commonjs babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/lib",
+    "build:react-redux-modules:es": "cross-env BABEL_ENV=es babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/es",
+    "build:redux-modules": "yarn run build:redux-modules:commonjs && yarn run build:redux-modules:es",
+    "build:redux-modules-test-utils": "yarn run build:redux-modules-test-utils:commonjs && yarn run build:redux-modules-test-utils:es",
+    "build:redux-modules-test-utils:commonjs": "cross-env BABEL_ENV=commonjs babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/lib",
+    "build:redux-modules-test-utils:es": "cross-env BABEL_ENV=es babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/es",
+    "build:redux-modules:commonjs": "cross-env BABEL_ENV=commonjs babel packages/redux-modules/src --out-dir packages/redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/lib",
+    "build:redux-modules:es": "cross-env BABEL_ENV=es babel packages/redux-modules/src --out-dir packages/redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/es",
     "clean": "rimraf packages/**/es packages/**/lib",
     "flow": "flow",
     "jest": "jest --coverage",
     "lint": "eslint packages/**/src/*.js packages/**/__tests__/*.js",
     "lint:fix": "eslint packages/**/*.js --fix",
-    "prettier:lint":
-      "prettier --l --no-bracket-spacing --single-quote --trailing-comma all \"packages/**/*.js\"",
-    "prettier:write":
-      "prettier --no-bracket-spacing --single-quote --trailing-comma all --write \"packages/**/*.js\"",
+    "prettier:lint": "prettier --l --no-bracket-spacing --single-quote --trailing-comma all \"packages/**/*.js\"",
+    "prettier:write": "prettier --no-bracket-spacing --single-quote --trailing-comma all --write \"packages/**/*.js\"",
     "publish": "yarn run clean && yarn run build && lerna publish",
     "test": "yarn run lint && yarn run flow && yarn run jest"
   },
-  "workspaces": ["packages/*"]
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,29 +40,42 @@
     "node": ">=4",
     "yarn": ">=1"
   },
+  "jest": {
+    "testMatch": ["**/*.test.js"]
+  },
   "private": "true",
   "scripts": {
-    "build": "yarn run build:redux-modules && yarn run build:react-redux-modules && yarn run build:redux-modules-test-utils",
-    "build:react-redux-modules": "yarn run build:react-redux-modules:commonjs && yarn run build:react-redux-modules:es",
-    "build:react-redux-modules:commonjs": "cross-env BABEL_ENV=commonjs babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/lib",
-    "build:react-redux-modules:es": "cross-env BABEL_ENV=es babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/es",
-    "build:redux-modules": "yarn run build:redux-modules:commonjs && yarn run build:redux-modules:es",
-    "build:redux-modules-test-utils": "yarn run build:redux-modules-test-utils:commonjs && yarn run build:redux-modules-test-utils:es",
-    "build:redux-modules-test-utils:commonjs": "cross-env BABEL_ENV=commonjs babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/lib",
-    "build:redux-modules-test-utils:es": "cross-env BABEL_ENV=es babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/es",
-    "build:redux-modules:commonjs": "cross-env BABEL_ENV=commonjs babel packages/redux-modules/src --out-dir packages/redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/lib",
-    "build:redux-modules:es": "cross-env BABEL_ENV=es babel packages/redux-modules/src --out-dir packages/redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/es",
+    "build":
+      "yarn run build:redux-modules && yarn run build:react-redux-modules && yarn run build:redux-modules-test-utils",
+    "build:react-redux-modules":
+      "yarn run build:react-redux-modules:commonjs && yarn run build:react-redux-modules:es",
+    "build:react-redux-modules:commonjs":
+      "cross-env BABEL_ENV=commonjs babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/lib",
+    "build:react-redux-modules:es":
+      "cross-env BABEL_ENV=es babel packages/react-redux-modules/src --out-dir packages/react-redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/react-redux-modules/src packages/react-redux-modules/es",
+    "build:redux-modules":
+      "yarn run build:redux-modules:commonjs && yarn run build:redux-modules:es",
+    "build:redux-modules-test-utils":
+      "yarn run build:redux-modules-test-utils:commonjs && yarn run build:redux-modules-test-utils:es",
+    "build:redux-modules-test-utils:commonjs":
+      "cross-env BABEL_ENV=commonjs babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/lib",
+    "build:redux-modules-test-utils:es":
+      "cross-env BABEL_ENV=es babel packages/redux-modules-test-utils/src --out-dir packages/redux-modules-test-utils/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules-test-utils/src packages/redux-modules-test-utils/es",
+    "build:redux-modules:commonjs":
+      "cross-env BABEL_ENV=commonjs babel packages/redux-modules/src --out-dir packages/redux-modules/lib -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/lib",
+    "build:redux-modules:es":
+      "cross-env BABEL_ENV=es babel packages/redux-modules/src --out-dir packages/redux-modules/es -i \"/node_modules|__tests__/\" && flow-copy-source packages/redux-modules/src packages/redux-modules/es",
     "clean": "rimraf packages/**/es packages/**/lib",
     "flow": "flow",
     "jest": "jest --coverage",
     "lint": "eslint packages/**/src/*.js packages/**/__tests__/*.js",
     "lint:fix": "eslint packages/**/*.js --fix",
-    "prettier:lint": "prettier --l --no-bracket-spacing --single-quote --trailing-comma all \"packages/**/*.js\"",
-    "prettier:write": "prettier --no-bracket-spacing --single-quote --trailing-comma all --write \"packages/**/*.js\"",
+    "prettier:lint":
+      "prettier --l --no-bracket-spacing --single-quote --trailing-comma all \"packages/**/*.js\"",
+    "prettier:write":
+      "prettier --no-bracket-spacing --single-quote --trailing-comma all --write \"packages/**/*.js\"",
     "publish": "yarn run clean && yarn run build && lerna publish",
     "test": "yarn run lint && yarn run flow && yarn run jest"
   },
-  "workspaces": [
-    "packages/*"
-  ]
+  "workspaces": ["packages/*"]
 }

--- a/packages/react-redux-modules/__tests__/.eslintrc.js
+++ b/packages/react-redux-modules/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'require-jsdoc': 0,
+  },
+};

--- a/packages/redux-modules-test-utils/__tests__/.eslintrc.js
+++ b/packages/redux-modules-test-utils/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'require-jsdoc': 0,
+  },
+};

--- a/packages/redux-modules/__tests__/.eslintrc.js
+++ b/packages/redux-modules/__tests__/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'require-jsdoc': 0,
+  },
+};

--- a/packages/redux-modules/__tests__/createModule.test.js
+++ b/packages/redux-modules/__tests__/createModule.test.js
@@ -12,7 +12,6 @@ import type {
   ReduxModule,
 } from '../src/types';
 
-
 function harness<S: Object, C: ImplicitTransformations<S>>(
   options: CreateModuleOptions<S, C>,
 ): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {

--- a/packages/redux-modules/__tests__/createModule.test.js
+++ b/packages/redux-modules/__tests__/createModule.test.js
@@ -12,7 +12,7 @@ import type {
   ReduxModule,
 } from '../src/types';
 
-// eslint-disable-next-line require-jsdoc
+
 function harness<S: Object, C: ImplicitTransformations<S>>(
   options: CreateModuleOptions<S, C>,
 ): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {

--- a/packages/redux-modules/__tests__/defaultModuleCreator.test.js
+++ b/packages/redux-modules/__tests__/defaultModuleCreator.test.js
@@ -12,7 +12,6 @@ import type {
   // Transformations,
 } from '../src/types';
 
-
 function harness<S: Object, C: {}>(
   options: NormalizedCreateModuleOptions<S, C>,
 ): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {

--- a/packages/redux-modules/__tests__/defaultModuleCreator.test.js
+++ b/packages/redux-modules/__tests__/defaultModuleCreator.test.js
@@ -12,7 +12,7 @@ import type {
   // Transformations,
 } from '../src/types';
 
-// eslint-disable-next-line require-jsdoc
+
 function harness<S: Object, C: {}>(
   options: NormalizedCreateModuleOptions<S, C>,
 ): ReduxModule<S, $ObjMap<C, ExtractActionCreatorType>> {

--- a/packages/redux-modules/__tests__/normalizeOptions.test.js
+++ b/packages/redux-modules/__tests__/normalizeOptions.test.js
@@ -9,7 +9,6 @@ import type {
   Transformation,
 } from '../src/types';
 
-
 function harness<S: Object, C: ImplicitTransformations<S>>(
   options: CreateModuleOptions<S, C>,
 ) {

--- a/packages/redux-modules/__tests__/normalizeOptions.test.js
+++ b/packages/redux-modules/__tests__/normalizeOptions.test.js
@@ -9,7 +9,7 @@ import type {
   Transformation,
 } from '../src/types';
 
-// eslint-disable-next-line require-jsdoc
+
 function harness<S: Object, C: ImplicitTransformations<S>>(
   options: CreateModuleOptions<S, C>,
 ) {

--- a/packages/redux-modules/__tests__/normalizeTransformation.test.js
+++ b/packages/redux-modules/__tests__/normalizeTransformation.test.js
@@ -2,7 +2,6 @@
 import normalizeTransformation from '../src/normalizeTransformation';
 import type {ImplicitTransformation} from '../src/types';
 
-
 function harness<S: Object, P, M>(
   transformation: ImplicitTransformation<S, P, M>,
 ) {

--- a/packages/redux-modules/__tests__/normalizeTransformation.test.js
+++ b/packages/redux-modules/__tests__/normalizeTransformation.test.js
@@ -2,7 +2,7 @@
 import normalizeTransformation from '../src/normalizeTransformation';
 import type {ImplicitTransformation} from '../src/types';
 
-// eslint-disable-next-line require-jsdoc
+
 function harness<S: Object, P, M>(
   transformation: ImplicitTransformation<S, P, M>,
 ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,12 +443,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.0.2.tgz#817ea52c23f1c6c4b684d6960968416b6a9e9c6c"
+babel-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-21.2.0.tgz#2ce059519a9374a2c46f2455b6fbef5ad75d863e"
   dependencies:
     babel-plugin-istanbul "^4.0.0"
-    babel-preset-jest "^21.0.2"
+    babel-preset-jest "^21.2.0"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -470,9 +470,9 @@ babel-plugin-istanbul@^4.0.0:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
-babel-plugin-jest-hoist@^21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.0.2.tgz#cfdce5bca40d772a056cb8528ad159c7bb4bb03d"
+babel-plugin-jest-hoist@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
 
 babel-plugin-lodash@^3.2.11:
   version "3.2.11"
@@ -529,7 +529,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -885,11 +885,12 @@ babel-preset-flow@^6.23.0:
   dependencies:
     babel-plugin-transform-flow-strip-types "^6.22.0"
 
-babel-preset-jest@^21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.0.2.tgz#9db25def2329f49eace3f5ea0de42a0b898d12cc"
+babel-preset-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
   dependencies:
-    babel-plugin-jest-hoist "^21.0.2"
+    babel-plugin-jest-hoist "^21.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-preset-react@^6.23.0:
   version "6.24.1"
@@ -1430,14 +1431,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-env@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
@@ -1674,9 +1667,9 @@ escodegen@^1.6.1:
   optionalDependencies:
     source-map "~0.5.6"
 
-eslint-config-fb-strict@^21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/eslint-config-fb-strict/-/eslint-config-fb-strict-21.0.2.tgz#026aaf887002d4a5c9c934ccc6518beb254e42cd"
+eslint-config-fb-strict@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-fb-strict/-/eslint-config-fb-strict-21.2.0.tgz#17f1522b78d7c7be30a00f732e6d823d68cd0e17"
   dependencies:
     eslint-config-fbjs "^2.0.0"
 
@@ -1727,9 +1720,9 @@ eslint-plugin-jasmine@^2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.8.4.tgz#67a5551e3d1d5e0b8c6b54aaebab95370f5d37de"
 
-eslint-plugin-jest@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.1.0.tgz#2897f405e4db88f39d88b4aa10800983831cdeb9"
+eslint-plugin-jest@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.2.0.tgz#292044df9cf0866ad9c530e78e6528fae287b926"
 
 eslint-plugin-jsx-a11y@^6.0.2:
   version "6.0.2"
@@ -1889,16 +1882,16 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-21.1.0.tgz#1c138ec803c72d28cbd10dfe97104966d967c24a"
+expect@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^21.1.0"
-    jest-get-type "^21.0.2"
-    jest-matcher-utils "^21.1.0"
-    jest-message-util "^21.1.0"
-    jest-regex-util "^21.1.0"
+    jest-diff "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
 
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
@@ -1936,7 +1929,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2724,15 +2717,15 @@ iterall@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
 
-jest-changed-files@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.1.0.tgz#e70f6b33b75d5987f4eae07e35bea5525635f92a"
+jest-changed-files@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.1.0.tgz#4f671885ea3521803c96a1fd95baaa6a1ba8d70f"
+jest-cli@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -2743,17 +2736,17 @@ jest-cli@^21.1.0:
     istanbul-lib-coverage "^1.0.1"
     istanbul-lib-instrument "^1.4.2"
     istanbul-lib-source-maps "^1.1.0"
-    jest-changed-files "^21.1.0"
-    jest-config "^21.1.0"
-    jest-environment-jsdom "^21.1.0"
-    jest-haste-map "^21.1.0"
-    jest-message-util "^21.1.0"
-    jest-regex-util "^21.1.0"
-    jest-resolve-dependencies "^21.1.0"
-    jest-runner "^21.1.0"
-    jest-runtime "^21.1.0"
-    jest-snapshot "^21.1.0"
-    jest-util "^21.1.0"
+    jest-changed-files "^21.2.0"
+    jest-config "^21.2.1"
+    jest-environment-jsdom "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve-dependencies "^21.2.0"
+    jest-runner "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-snapshot "^21.2.1"
+    jest-util "^21.2.1"
     micromatch "^2.3.11"
     node-notifier "^5.0.2"
     pify "^3.0.0"
@@ -2764,146 +2757,146 @@ jest-cli@^21.1.0:
     worker-farm "^1.3.1"
     yargs "^9.0.0"
 
-jest-config@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.1.0.tgz#7ef8778af679de30dad75e355a0dfbb0330b8d2f"
+jest-config@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^21.1.0"
-    jest-environment-node "^21.1.0"
-    jest-get-type "^21.0.2"
-    jest-jasmine2 "^21.1.0"
-    jest-regex-util "^21.1.0"
-    jest-resolve "^21.1.0"
-    jest-util "^21.1.0"
-    jest-validate "^21.1.0"
-    pretty-format "^21.1.0"
+    jest-environment-jsdom "^21.2.1"
+    jest-environment-node "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
+    jest-validate "^21.2.1"
+    pretty-format "^21.2.1"
 
-jest-diff@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.1.0.tgz#ca4c9d40272a6901dcde6c4c0bb2f568c363cc42"
+jest-diff@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^21.0.2"
-    pretty-format "^21.1.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
 
-jest-docblock@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.1.0.tgz#43154be2441fb91403e36bb35cb791a5017cea81"
+jest-docblock@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
 
-jest-environment-jsdom@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.1.0.tgz#40729a60cd4544625f7d3a33c32bdaad63e57db7"
+jest-environment-jsdom@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
   dependencies:
-    jest-mock "^21.1.0"
-    jest-util "^21.1.0"
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
     jsdom "^9.12.0"
 
-jest-environment-node@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.1.0.tgz#a11fd611e8ae6c3e02b785aa1b12a3009f4fd0f1"
+jest-environment-node@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
   dependencies:
-    jest-mock "^21.1.0"
-    jest-util "^21.1.0"
+    jest-mock "^21.2.0"
+    jest-util "^21.2.1"
 
-jest-get-type@^21.0.2:
-  version "21.0.2"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.0.2.tgz#304e6b816dd33cd1f47aba0597bcad258a509fc6"
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
 
-jest-haste-map@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.1.0.tgz#08e7a8c584008d4b790b8dddf7dd3e3db03b75d3"
+jest-haste-map@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^21.1.0"
+    jest-docblock "^21.2.0"
     micromatch "^2.3.11"
     sane "^2.0.0"
     worker-farm "^1.3.1"
 
-jest-jasmine2@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.1.0.tgz#975c3cd3ecd9d50d385bfe3c680dd61979f50c9c"
+jest-jasmine2@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
   dependencies:
     chalk "^2.0.1"
-    expect "^21.1.0"
+    expect "^21.2.1"
     graceful-fs "^4.1.11"
-    jest-diff "^21.1.0"
-    jest-matcher-utils "^21.1.0"
-    jest-message-util "^21.1.0"
-    jest-snapshot "^21.1.0"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-snapshot "^21.2.1"
     p-cancelable "^0.3.0"
 
-jest-matcher-utils@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.1.0.tgz#b02e237b287c58915ce9a5bf3c7138dba95125a7"
+jest-matcher-utils@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^21.0.2"
-    pretty-format "^21.1.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
 
-jest-message-util@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.1.0.tgz#7f9a52535d1a640af0d4c800edde737e14ea0526"
+jest-message-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
   dependencies:
     chalk "^2.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
 
-jest-mock@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.1.0.tgz#c4dddfa893a0b120b72b5ae87c7506745213a790"
+jest-mock@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
 
-jest-regex-util@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.1.0.tgz#59e4bad74f5ffd62a3835225f9bc1ee3796b5adb"
+jest-regex-util@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
 
-jest-resolve-dependencies@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.1.0.tgz#9f78852e65d864d04ad0919ac8226b3f1434e7b0"
+jest-resolve-dependencies@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
   dependencies:
-    jest-regex-util "^21.1.0"
+    jest-regex-util "^21.2.0"
 
-jest-resolve@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.1.0.tgz#6bb806ca5ad876c250044fe62f298321d2da5c06"
+jest-resolve@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     is-builtin-module "^1.0.0"
 
-jest-runner@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.1.0.tgz#d7ea7e2fa10ed673d4dd25ba2f3faae2efb89a07"
+jest-runner@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
   dependencies:
-    jest-config "^21.1.0"
-    jest-docblock "^21.1.0"
-    jest-haste-map "^21.1.0"
-    jest-jasmine2 "^21.1.0"
-    jest-message-util "^21.1.0"
-    jest-runtime "^21.1.0"
-    jest-util "^21.1.0"
+    jest-config "^21.2.1"
+    jest-docblock "^21.2.0"
+    jest-haste-map "^21.2.0"
+    jest-jasmine2 "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-runtime "^21.2.1"
+    jest-util "^21.2.1"
     pify "^3.0.0"
     throat "^4.0.0"
     worker-farm "^1.3.1"
 
-jest-runtime@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.1.0.tgz#c9a180a9e06ef046d0ad157dea52355abb7cbad4"
+jest-runtime@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^21.0.2"
+    babel-jest "^21.2.0"
     babel-plugin-istanbul "^4.0.0"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
     graceful-fs "^4.1.11"
-    jest-config "^21.1.0"
-    jest-haste-map "^21.1.0"
-    jest-regex-util "^21.1.0"
-    jest-resolve "^21.1.0"
-    jest-util "^21.1.0"
+    jest-config "^21.2.1"
+    jest-haste-map "^21.2.0"
+    jest-regex-util "^21.2.0"
+    jest-resolve "^21.2.0"
+    jest-util "^21.2.1"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     slash "^1.0.0"
@@ -2911,43 +2904,43 @@ jest-runtime@^21.1.0:
     write-file-atomic "^2.1.0"
     yargs "^9.0.0"
 
-jest-snapshot@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.1.0.tgz#a5fa9d52847d8f52e19a1df6ccae9de699193ccc"
+jest-snapshot@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^21.1.0"
-    jest-matcher-utils "^21.1.0"
+    jest-diff "^21.2.1"
+    jest-matcher-utils "^21.2.1"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^21.1.0"
+    pretty-format "^21.2.1"
 
-jest-util@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.1.0.tgz#f92ff756422cc0609ddf5a9bfa4d34b2835d8c30"
+jest-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
-    jest-message-util "^21.1.0"
-    jest-mock "^21.1.0"
-    jest-validate "^21.1.0"
+    jest-message-util "^21.2.1"
+    jest-mock "^21.2.0"
+    jest-validate "^21.2.1"
     mkdirp "^0.5.1"
 
-jest-validate@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.1.0.tgz#39d01115544a758bce49f221a5fcbb24ebdecc65"
+jest-validate@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^21.0.2"
+    jest-get-type "^21.2.0"
     leven "^2.1.0"
-    pretty-format "^21.1.0"
+    pretty-format "^21.2.1"
 
-jest@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-21.1.0.tgz#77c7baa8aa9e8bace7fe41a30d748ab56e89476a"
+jest@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
   dependencies:
-    jest-cli "^21.1.0"
+    jest-cli "^21.2.1"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -3655,13 +3648,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
+prettier@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.2.tgz#81371e64018aafc69cf1031956c70e029339f54e"
 
-pretty-format@^21.1.0:
-  version "21.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.1.0.tgz#557428254323832ee8b7c971cb613442bea67f61"
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -3684,7 +3677,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -3732,14 +3725,14 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+react-dom@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-redux@^5.0.6:
   version "5.0.6"
@@ -3775,15 +3768,14 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react@^15.6.1:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
So now I don't have to put `// eslint-disable-next-line require-jsdoc` in every test file.